### PR TITLE
UrlHelper now handles url parameters

### DIFF
--- a/PayCheckServerLib/Helpers/UrlHelper.cs
+++ b/PayCheckServerLib/Helpers/UrlHelper.cs
@@ -10,8 +10,8 @@
             if (string.IsNullOrEmpty(pattern)) throw new ArgumentNullException(nameof(pattern));
 
             vals = new Dictionary<string, string>();
-            string[] urlParts = url.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-            string[] patternParts = pattern.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] urlParts = SplitUrl(url);
+            string[] patternParts = SplitUrl(pattern);
 
             if (urlParts.Length != patternParts.Length) return false;
 
@@ -32,7 +32,7 @@
                 {
                     vals.Add(
                         paramName.Replace("{", "").Replace("}", ""),
-                        urlParts[i]);
+                        urlParts[i].Split('=').Last());
                 }
             }
             return true;
@@ -57,6 +57,35 @@
 
             return string.Empty;
         }
+        
+        private static string[] SplitUrl(string url)
+        {
+            string[] urlPaths = url.Split('/', StringSplitOptions.RemoveEmptyEntries);;
+            urlPaths = SplitUrl(urlPaths, '?');
+            urlPaths = SplitUrl(urlPaths, '&');
+
+            return urlPaths;
+        }
+
+        private static string[] SplitUrl(string[] urlParts, char splitChar)
+        {
+            List<string> parts = new List<string>();
+
+            foreach (var part in urlParts)
+            {
+                if (!part.Contains(splitChar))
+                {
+                    parts.Add(part);
+                    continue;
+                }
+
+                string[] subParts = part.Split(splitChar, StringSplitOptions.RemoveEmptyEntries);
+                parts.AddRange(subParts);
+            }
+
+            return parts.ToArray();
+        }
+        
         #endregion
     }
 }

--- a/PayCheckServerLib/Responses/Challenge.cs
+++ b/PayCheckServerLib/Responses/Challenge.cs
@@ -19,9 +19,8 @@ namespace PayCheckServerLib.Responses
         [HTTP("GET", "/challenge/v1/public/namespaces/pd3/users/me/records?limit={limit}&offset={offset}")]
         public static bool ChallengeRecordsSplit(HttpRequest _, PC3Server.PC3Session session)
         {
-            var limit_offset = session.HttpParam["limit&offset=offset"].Replace("records?limit=","").Replace("offset=", ""); //records?limit=100&offset=0
-            var offset = int.Parse(limit_offset.Split("&")[1]);
-            var limit = int.Parse(limit_offset.Split("&")[0]);
+            var offset = int.Parse(session.HttpParam["offset"]);
+            var limit = int.Parse(session.HttpParam["limit"]);
             var auth = session.Headers["authorization"].Replace("Bearer ", "");
             var token = TokenHelper.ReadToken(auth);
             ResponseCreator creator = new();


### PR DESCRIPTION
Allows the UrlHelper to handle url's with multiple query parameters in a single path. for example `/challenge/v1/public/namespaces/pd3/users/me/records?limit={limit}&offset={offset}` it does additional url splitting with the chars `?` and `&`.